### PR TITLE
fix implementation of the rate limiter and the echo middleware function

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,14 @@ import (
 var db *sql.DB
 var data *model.ServerData
 
+// vars for the rate limiting middleware
+var (
+	indexLimit          = 60
+	indexLimitCarrier   = 3600
+	indexLimiter        golimiter.Limiter
+	indexLimiterCarrier golimiter.Limiter
+)
+
 func main() {
 
 	// Init Logrus and configure channels
@@ -63,7 +71,7 @@ func main() {
 }
 
 // Start Internals-API Backend server
-// Configure Handler, limit middleware, TLS
+// Configure Handler, indexLimit middleware, TLS
 func startServer() {
 	utils.SetSetting(model.GlobalSettings{ValidateCallerId: false})
 
@@ -72,7 +80,9 @@ func startServer() {
 	utils.Log(logrus.InfoLevel, "Starting HTTP server...")
 	// Configure Limit Handler if USE_LIMIT_MIDDLEWARE is "on"
 	if utils.Config("USE_LIMIT_MIDDLEWARE") == "on" {
-		r.Any("", limitHandler)
+		indexLimiter = golimiter.New(indexLimit, time.Minute)
+		indexLimiterCarrier = golimiter.New(indexLimitCarrier, time.Minute)
+		r.Use(limitHandler)
 	}
 
 	// Configure Handler with Global DB
@@ -109,43 +119,39 @@ func startServer() {
 }
 
 // Configure Limit Handler for Echo context
-func limitHandler(c echo.Context) error {
-	var addr string
-	requestedAddr := c.QueryParam("addr")
-	if requestedAddr == "" {
-		addr = requestedAddr
-	} else {
-		addr = c.RealIP()
+func limitHandler(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var addr string
+		requestedAddr := c.QueryParam("addr")
+		if requestedAddr == "" {
+			addr = requestedAddr
+		} else {
+			addr = c.RealIP()
+		}
+
+		carrier := c.Request().Header.Get("X-Lineblocs-Carrier-Auth")
+		isCarrier := false
+
+		if carrier != "" {
+			isCarrier = utils.CheckIfCarrier(carrier)
+		}
+
+		// Limit for users
+		var useLimiter golimiter.Limiter
+		if isCarrier {
+			useLimiter = indexLimiterCarrier
+		} else {
+			useLimiter = indexLimiter
+		}
+
+		// Check if the given IP is rate limited
+		if useLimiter.IsLimited(addr) {
+			return c.String(http.StatusTooManyRequests, fmt.Sprintf("Rate indexLimit exhausted from %s", addr))
+		}
+		// Add a request to the count for the Ip
+		useLimiter.Increment(addr)
+
+		// Tell echo to continue the request
+		return next(c)
 	}
-
-	carrier := c.Request().Header.Get("X-Lineblocs-Carrier-Auth")
-	isCarrier := false
-
-	if carrier != "" {
-		isCarrier = utils.CheckIfCarrier(carrier)
-	}
-
-	// Limit for users
-
-	var limit int = 60
-	if isCarrier {
-		limit = 3600
-	}
-
-	var indexLimiter = golimiter.New(limit, time.Minute)
-
-	// Check if the given IP is rate limited
-	if indexLimiter.IsLimited(addr) {
-		return c.String(http.StatusTooManyRequests, fmt.Sprintf("Rate limit exhausted from %s", addr))
-	}
-	// Add a request to the count for the Ip
-	indexLimiter.Increment(addr)
-	totalRequestPastMinute := indexLimiter.Count(addr)
-	totalRemaining := limit - totalRequestPastMinute
-	return c.String(http.StatusOK, fmt.Sprintf(""+
-		"Your IP %s is not rate limited!\n"+
-		"You made %d requests in the last minute.\n"+
-		"You are allowed to make %d more request.\n"+
-		"Maximum request you can make per minute is %d.",
-		addr, totalRequestPastMinute, totalRemaining, limit))
 }


### PR DESCRIPTION
Suggested fix for issue https://github.com/Lineblocs/internals-api/issues/7

Also fixed the middleware implementation for the echo Server.

[Any()](https://pkg.go.dev/github.com/labstack/echo/v4#Group.Any) is used to match any http request. While the [Use()](https://pkg.go.dev/github.com/labstack/echo/v4#Group.Use) is used to register middleware, allowing for the next handlers and routes to handle the request.

It builds but correctly but did not ran it, it's only a suggestion, test before pulling.